### PR TITLE
Avoid to raise error with Ruby 1.9+/2.0

### DIFF
--- a/lib/rack/heroku/no-such-app.rb
+++ b/lib/rack/heroku/no-such-app.rb
@@ -11,7 +11,7 @@ module Rack
 
       def call(env)
         if HEROKUAPP_DOMAIN_REGEXP === (env['HTTP_HOST'] || env['SERVER_NAME'])
-          return [404, headers, body]
+          return [404, headers, [body]]
         end
 
         @app.call(env)


### PR DESCRIPTION
A string is not a valid Rack response in Ruby 1.9+.

See: https://github.com/rack/rack/issues/548
